### PR TITLE
feat: add newline option

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -5,6 +5,10 @@ inputs:
   token:
     description: GitHub access token
     required: true
+  newline:
+    description: Requires final newline for all configuration files
+    required: false
+    default: false
 runs:
   using: docker
   image: "Dockerfile"

--- a/internal/entity/config.go
+++ b/internal/entity/config.go
@@ -6,7 +6,8 @@ import (
 )
 
 type Configuration struct {
-	Token string
+	Token   string
+	Newline bool
 }
 
 func CreateConfiguration() (*Configuration, error) {
@@ -16,7 +17,10 @@ func CreateConfiguration() (*Configuration, error) {
 		return nil, constant.ErrMissingToken
 	}
 
+	newline := utils.ReadEnvBool("INPUT_NEWLINE")
+
 	return &Configuration{
-		Token: token,
+		Token:   token,
+		Newline: newline,
 	}, nil
 }

--- a/internal/entity/config_test.go
+++ b/internal/entity/config_test.go
@@ -24,10 +24,12 @@ func TestCreateConfiguration(t *testing.T) {
 		{
 			name: "success",
 			env: map[string]string{
-				"INPUT_TOKEN": "access-token",
+				"INPUT_TOKEN":   "access-token",
+				"INPUT_NEWLINE": "true",
 			},
 			want: &Configuration{
-				Token: "access-token",
+				Token:   "access-token",
+				Newline: true,
 			},
 			wantErr: nil,
 		},

--- a/internal/service/validator.go
+++ b/internal/service/validator.go
@@ -3,6 +3,7 @@ package service
 import (
 	"bytes"
 	"context"
+	"strings"
 	"sync"
 
 	"github.com/Namchee/konfigured/internal"
@@ -24,13 +25,16 @@ var (
 
 // ConfigurationValidator is a service that validates configuration files
 type ConfigurationValidator struct {
+	cfg    *entity.Configuration
 	client internal.GithubClient
 }
 
 func NewConfigurationValidator(
+	cfg *entity.Configuration,
 	client internal.GithubClient,
 ) *ConfigurationValidator {
 	return &ConfigurationValidator{
+		cfg:    cfg,
 		client: client,
 	}
 }
@@ -98,6 +102,10 @@ func (v *ConfigurationValidator) isValid(
 	content, err := fileContent.GetContent()
 	// always false if we are not able to test it
 	if err != nil {
+		return false
+	}
+
+	if v.cfg.Newline && !strings.HasSuffix(content, "\n") {
 		return false
 	}
 

--- a/internal/utils/env.go
+++ b/internal/utils/env.go
@@ -1,8 +1,24 @@
 package utils
 
-import "os"
+import (
+	"os"
+	"strconv"
+)
 
 // ReadEnvString returns string value from environment variables
 func ReadEnvString(key string) string {
 	return os.Getenv(key)
+}
+
+// ReadEnvBool read and parse boolean environment variables.
+// Will return `false` if the variable is not a `bool`
+func ReadEnvBool(key string) bool {
+	value := os.Getenv(key)
+	parsed, err := strconv.ParseBool(value)
+
+	if err != nil {
+		return false
+	}
+
+	return parsed
 }

--- a/internal/utils/env_test.go
+++ b/internal/utils/env_test.go
@@ -17,3 +17,38 @@ func TestReadEnvString(t *testing.T) {
 	res := ReadEnvString(key)
 	assert.Equal(t, value, res)
 }
+
+func TestReadEnvBool(t *testing.T) {
+	tests := []struct {
+		name      string
+		mockValue string
+		want      bool
+	}{
+		{
+			name:      "should read true correctly",
+			mockValue: "true",
+			want:      true,
+		},
+		{
+			name:      "should read false correctly",
+			mockValue: "false",
+			want:      false,
+		},
+		{
+			name:      "should fallback to false",
+			mockValue: "bar",
+			want:      false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			os.Setenv("TEST", tc.mockValue)
+			defer os.Unsetenv("TEST")
+
+			got := ReadEnvBool("TEST")
+
+			assert.Equal(t, got, tc.want)
+		})
+	}
+}

--- a/main.go
+++ b/main.go
@@ -66,7 +66,7 @@ func main() {
 		errorLogger.Fatalf("Failed to fetch list of file changes: %s", err.Error())
 	}
 
-	validator := service.NewConfigurationValidator(client)
+	validator := service.NewConfigurationValidator(config, client)
 	supportedFiles := validator.GetSupportedFiles(files)
 
 	infoLogger.Printf("Found %d supported configuration files", len(supportedFiles))


### PR DESCRIPTION
## Overview

Closes #2

This pull request adds require newline feature that enforces all configuration files to end with a newline character to be valid. This feature can be enabled with the `newline` option in the action input. Disabled by default.