### PR TITLE
docs: add hcl support to docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ You can customize this actions with these following options (fill it on `with` s
 | --------------------- | ------------- | --------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `token`        | `true`        |                                         | [GitHub access token](https://docs.github.com/en/free-pro-team@latest/github/authenticating-to-github/creating-a-personal-access-token) to interact with the GitHub API. It is recommended to store this token with [GitHub Secrets](https://docs.github.com/en/free-pro-team@latest/actions/reference/encrypted-secrets). **To support automatic close, labeling, and comment report, please grant a write access to the token** |
 | `newline` | `false` | `false` | Require all valid configuration file to end with newline.
-| `include` | `false` | `**/*.{json,ini,yaml,yml,toml}` | Files to be validated in [glob pattern](https://en.wikipedia.org/wiki/Glob_(programming)). If this option is omitted, the action will validate all configuration file.
+| `include` | `false` | `**/*.{json,ini,yaml,yml,toml,hcl}` | Files to be validated in [glob pattern](https://en.wikipedia.org/wiki/Glob_(programming)). If this option is omitted, the action will validate all configuration file.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ Below are the currently supported configuration files that will be validated by 
 - `.json`
 - `.yaml`, `.yml`
 - `.toml`
+- `.hcl`
 
 ## Inputs
 

--- a/action.yml
+++ b/action.yml
@@ -12,7 +12,7 @@ inputs:
   include:
     description: Files to be validated
     required: false
-    default: '**/*.{json,ini,yaml,yml,toml}'
+    default: '**/*.{json,ini,yaml,yml,toml,hcl}'
 runs:
   using: docker
   image: "Dockerfile"

--- a/internal/entity/config.go
+++ b/internal/entity/config.go
@@ -8,7 +8,7 @@ import (
 )
 
 const (
-	defaultPattern = "**/*.{json,ini,yaml,yml,toml}"
+	defaultPattern = "**/*.{json,ini,yaml,yml,toml,hcl}"
 )
 
 type Configuration struct {

--- a/internal/service/validator.go
+++ b/internal/service/validator.go
@@ -21,6 +21,7 @@ var (
 		"yaml",
 		"yml",
 		"toml",
+		"hcl",
 	}
 )
 

--- a/internal/service/validator_test.go
+++ b/internal/service/validator_test.go
@@ -3,6 +3,7 @@ package service
 import (
 	"context"
 	"errors"
+	"fmt"
 	"testing"
 
 	"github.com/Namchee/konfigured/internal/entity"
@@ -52,6 +53,23 @@ func TestConfigurationValidator_ValidateConfigurationFiles(t *testing.T) {
 			},
 			err: nil,
 		},
+		"configuration.hcl": {
+			content: &github.RepositoryContent{
+				Content: github.String(`example {
+  foo = "bar"
+}
+`),
+			},
+			err: nil,
+		},
+		"invalid.hcl": {
+			content: &github.RepositoryContent{
+				Content: github.String(`example {
+  foo = "
+}`),
+			},
+			err: nil,
+		},
 		"no-newline.yaml": {
 			content: &github.RepositoryContent{
 				Content: github.String("key: value"),
@@ -84,6 +102,12 @@ func TestConfigurationValidator_ValidateConfigurationFiles(t *testing.T) {
 			Filename: github.String("config.yaml"),
 		},
 		{
+			Filename: github.String("configuration.hcl"),
+		},
+		{
+			Filename: github.String("invalid.hcl"),
+		},
+		{
 			Filename: github.String("no-newline.yaml"),
 		},
 		{
@@ -113,16 +137,18 @@ func TestConfigurationValidator_ValidateConfigurationFiles(t *testing.T) {
 	validator := &ConfigurationValidator{
 		cfg: &entity.Configuration{
 			Newline: true,
-			Include: "**/*.{json,ini,yaml,toml}",
+			Include: "**/*.{json,ini,yaml,toml,hcl}",
 		},
 		client: client,
 	}
 
 	got := validator.ValidateFiles(context.TODO(), args)
 
-	assert.Equal(t, 6, len(got))
+	assert.Equal(t, 8, len(got))
 
 	invalids := entity.GetInvalidValidations(got)
 
-	assert.Equal(t, 4, len(invalids))
+	fmt.Println(invalids)
+
+	assert.Equal(t, 5, len(invalids))
 }


### PR DESCRIPTION
## Overview

This pull request adds `.hcl` to the default value of `include` in the `README`